### PR TITLE
(feature): add --replace param to fork command

### DIFF
--- a/src/cmd/fork.rs
+++ b/src/cmd/fork.rs
@@ -1,8 +1,11 @@
-use crate::api_service::ApiService;
-use crate::types::ForkRequest;
-use crate::utils::{check_and_create_dir, write_sources_and_conf};
-use clap::{Parser, ValueHint};
 use std::path::PathBuf;
+
+use clap::{Parser, ValueHint};
+use eyre::eyre;
+
+use crate::api_service::ApiService;
+use crate::types::{ForkRequest, GraphConfig};
+use crate::utils::{check_and_create_dir, write_sources_and_conf};
 
 #[derive(Clone, Debug, Default, Parser)]
 pub struct ForkCmd {
@@ -17,14 +20,24 @@ pub struct ForkCmd {
     /// Name for this GhostGraph. (defaults to dir name if not provided)
     #[arg(long, short)]
     pub name: Option<String>,
+
+    /// Fork a graph and replace the current config and source files.
+    #[arg(long, short)]
+    pub replace: bool,
 }
 
 impl ForkCmd {
     pub async fn run(self, api: &ApiService) -> eyre::Result<()> {
-        let Self { dir, id, name } = self;
+        let Self { mut dir, id, name, replace } = self;
         println!("Forking graph with ID: {}", id);
-        check_and_create_dir(&dir)?;
-        let name: Option<String> = name
+        if replace {
+            GraphConfig::read(PathBuf::from("config.json"))
+                .map_err(|_| eyre!("cannot read config.json. Must be in a Ghost directory"))?;
+            dir = PathBuf::from(".");
+        } else {
+            check_and_create_dir(&dir)?;
+        }
+        let name = name
             .or_else(|| dir.file_name().and_then(|os_str| os_str.to_str()).map(|s| s.to_string()));
         let resp = api.fork_graph(&id, &ForkRequest { name }).await?;
         println!("Graph has been successfully forked. Setting up local files...");


### PR DESCRIPTION
### Overview
Add --replace param to fork command

### Testing 
`ghost fork --id <id> <name> --replace` will fork and replace config and source files in the current Ghost directory

### User Flow
Users are in the Ghost directory and want to fork a graph without creating a new directory.
This new param `--replace` allows users to fork and replace the config and source files, eliminating the need for an additional directory.